### PR TITLE
fix: specify vscode-extensions volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.6'
 
-# volumes:
+volumes:
 #   zookeeper-data:
 #     driver: local
 #   zookeeper-log:
@@ -11,10 +11,9 @@ version: '3.6'
 #     driver: local
 #   pgadmin-data:
 #     driver: local
-#   vscode-extensions:
+  vscode-extensions:
 
 services:
-
   app:
     build:
       context: .


### PR DESCRIPTION
The reason the devcontainer wasn't working was because it uses a vscode-extensions volume, which had been commented out within the docker-compose previously. I uncommented it and now it works